### PR TITLE
Feature/enable disable segments

### DIFF
--- a/src/newrelic.ts
+++ b/src/newrelic.ts
@@ -63,7 +63,15 @@ function preload(this: any, opts: any) {
 function newrelic(this: any, options: NewRelicOptions) {
     const seneca: any = this
 
-    seneca.message('plugin:newrelic,get:info', get_info)
+    seneca
+      .message('plugin:newrelic,get:info', get_info)
+      .message({
+        sys:'telemetry',
+        telemetry:'newrelic',
+        active: Boolean
+      }, async function onOff(this: any, msg: any) {
+        Segments.emmiter().emit('statusChange', msg.active)
+      })
 
     if (seneca.metrics_api_key) {
       const { metric_count_handler, metric_summary_handler, metric_gauge_handler} = MetricsCollector(seneca.metrics_api_key);

--- a/src/newrelic.ts
+++ b/src/newrelic.ts
@@ -10,56 +10,6 @@ import { EventsCollector } from './events-collector';
 
 import { NewRelicOptions, Nullable, Spec } from './types';
 
-function addSegment(spec: Spec) {
-  if (spec.ctx.actdef?.func) {
-    const { ctx, data } = spec
-    const pattern = ctx.actdef.pattern
-    const origfunc = ctx.actdef.func
-    const meta = data.meta
-    const context = ctx.seneca.context
-    
-    if(ctx.actdef.func.$$newrelic_wrapped$$) {
-      return
-    }
-
-    // ensure each action has it's own endSegment
-    context.newrelic = context.newrelic || {}
-    let endSegmentMap =
-      (context.newrelic.endSegmentMap = context.newrelic.endSegmentMap || {})
-
-    ctx.actdef.func = function(this: any, ...args: any) {
-      const instance = this
-      NewRelic.startSegment(
-        pattern + '~' + origfunc.name,
-        true,
-        function handler(endSegmentHandler: any) {
-          endSegmentMap[meta.mi] = (endSegmentMap[meta.mi] || {})
-          endSegmentMap[meta.mi].endSegmentHandler = endSegmentHandler
-          return origfunc.call(instance, ...args)
-        },
-        function endSegmentHandler() { }
-      )
-
-      ctx.actdef.func.$$newrelic_wrapped$$ = true;
-    }
-
-    Object.defineProperty(
-      ctx.actdef.func, 'name', { value: 'newrelic_' + origfunc.name })
-  }
-}
-
-function endSegment(spec: Spec) {
-  const meta = spec.data.meta
-  const context = spec.ctx.seneca.context
-  const endSegmentMap = context.newrelic?.endSegmentMap
-  if (endSegmentMap && endSegmentMap[meta.mi]) {
-    const endSegmentHandler = endSegmentMap[meta.mi].endSegmentHandler
-    if (endSegmentHandler) {
-      delete endSegmentMap[meta.mi]
-      endSegmentHandler()
-    }
-  }
-}
 
 function preload(this: any, opts: any) {
   const seneca = this;

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -1,0 +1,73 @@
+import EventEmitter from "events"
+import { Spec } from "../types"
+import { SegmentShim, shim } from "./shim"
+
+export class Segments extends EventEmitter {
+  inwardTasks: Record<string, (spec: Spec) => void> = {}
+  outwardTasks: Record<string, (spec: Spec) => void> = {}
+  shim: SegmentShim
+  status: boolean = false
+  static emitter: Segments | undefined
+
+  private constructor() {
+    super()
+
+    this.inwardTasks = {}
+    this.outwardTasks = {}
+
+    this.shim = shim()
+
+    this
+      .on('disablePlugin', () => {
+        this.inwardTasks = { remove_segment: this.shim.remove_segment }
+      })
+      .on('disableSegments', () => {
+        this.inwardTasks = { remove_segment: this.shim.remove_segment }
+      })
+      .on('enableSegments', () => {
+        this.inwardTasks = { ...(this.inwardTasks), add_segment: this.shim.add_segment }
+        this.outwardTasks = { ...(this.outwardTasks), end_segment: this.shim.end_segment }
+      })
+      .on('statusChange', (status: boolean) => {
+        if(this.status === true && status === true) {
+          return
+        }
+        if(this.status === false && status === true) { // ON
+          this.emit('enableSegments')
+          this.status = true
+        } else if (this.status === true && status === false) { // OFF
+          this.emit('disableSegments')
+          this.status = false
+        }
+      })
+  }
+
+  static emmiter() {
+    if(this.emitter) {
+      return this.emitter
+    }
+    const segments = new Segments
+    this.emitter = segments
+    return segments
+  }
+
+  inward(spec: Spec) {
+    for(const [task, taskFunc] of Object.entries(this.inwardTasks)) {
+      taskFunc(spec)
+    }
+
+    this.on('removeAllSegments', () => {
+      this.shim.remove_segment(spec)
+    })
+
+    return this
+  }
+
+  outward(spec: Spec) {
+    for(const [task, taskFunc] of Object.entries(this.outwardTasks)) {
+      taskFunc(spec)
+    }
+
+    return this
+  }
+}   

--- a/src/segments/shim.ts
+++ b/src/segments/shim.ts
@@ -46,8 +46,6 @@ function shim(): SegmentShim {
       
       Object.defineProperty(
         ctx.actdef.func, 'name', { value: 'newrelic_' + origfunc.name })
-
-      console.log('segment added to ' + ctx.actdef.pattern + '~' + origfunc.name)
     }
   }
   
@@ -61,16 +59,13 @@ function shim(): SegmentShim {
         delete endSegmentMap[meta.mi]
         endSegmentHandler()
       }
-      console.log('segment ended for ' + (context.actdef?.pattern || 'n tem') + '~' + origfunc.name)
     }
   }
   
   function remove_segment(spec: Spec) {
     const { ctx, data } = spec
     if(ctx.actdef.func.$$newrelic_wrapped$$) {
-      console.log('removeSegment')
       spec.ctx.actdef.func = origfunc
-      console.log('segment removed for ' + ctx.actdef.pattern + '~' + origfunc.name)
     }
   }
 

--- a/src/segments/shim.ts
+++ b/src/segments/shim.ts
@@ -1,0 +1,86 @@
+import NewRelic from 'newrelic'
+import { Spec } from '../types'
+
+type SegmentShim = {
+  add_segment: (spec: Spec) => void
+  end_segment: (spec: Spec) => void
+  remove_segment: (spec: Spec) => void
+} 
+
+function shim(): SegmentShim {
+  let origfunc: Function
+
+  function add_segment(spec: Spec) {
+    if (spec.ctx.actdef?.func) {
+      const { ctx, data } = spec
+      const pattern = ctx.actdef.pattern
+      origfunc = ctx.actdef.func
+      const meta = data.meta
+      const context = ctx.seneca.context
+      
+      if(ctx.actdef.func.$$newrelic_wrapped$$) {
+        return
+      }
+  
+      // ensure each action has it's own endSegment
+      context.newrelic = context.newrelic || {}
+      let endSegmentMap =
+        (context.newrelic.endSegmentMap = context.newrelic.endSegmentMap || {})
+  
+      ctx.actdef.func = function(this: any, ...args: any) {
+        const instance = this
+        NewRelic.startSegment(
+          pattern + '~' + origfunc.name,
+          true,
+          function handler(endSegmentHandler: any) {
+            endSegmentMap[meta.mi] = (endSegmentMap[meta.mi] || {})
+            endSegmentMap[meta.mi].endSegmentHandler = endSegmentHandler
+            return origfunc.call(instance, ...args)
+          },
+          function endSegmentHandler() { }
+        )
+  
+      }
+
+      ctx.actdef.func.$$newrelic_wrapped$$ = true
+      
+      Object.defineProperty(
+        ctx.actdef.func, 'name', { value: 'newrelic_' + origfunc.name })
+
+      console.log('segment added to ' + ctx.actdef.pattern + '~' + origfunc.name)
+    }
+  }
+  
+  function end_segment(spec: Spec) {
+    const meta = spec.data.meta
+    const context = spec.ctx.seneca.context
+    const endSegmentMap = context.newrelic?.endSegmentMap
+    if (endSegmentMap && endSegmentMap[meta.mi]) {
+      const endSegmentHandler = endSegmentMap[meta.mi].endSegmentHandler
+      if (endSegmentHandler) {
+        delete endSegmentMap[meta.mi]
+        endSegmentHandler()
+      }
+      console.log('segment ended for ' + (context.actdef?.pattern || 'n tem') + '~' + origfunc.name)
+    }
+  }
+  
+  function remove_segment(spec: Spec) {
+    const { ctx, data } = spec
+    if(ctx.actdef.func.$$newrelic_wrapped$$) {
+      console.log('removeSegment')
+      spec.ctx.actdef.func = origfunc
+      console.log('segment removed for ' + ctx.actdef.pattern + '~' + origfunc.name)
+    }
+  }
+
+  return {
+    add_segment,
+    end_segment,
+    remove_segment,
+  }
+}
+
+export { shim }
+
+export type { SegmentShim }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type NewRelicOptions = {
+  active: boolean,
   tracing?: NewrelicTracingApi,
   segment?: NewrelicSegmentApi,
   metrics?: NewrelicMetricsApi,


### PR DESCRIPTION
The idea that led me to these changes was to create a class that are responsible for changing  inward/outward tasks (related to segments) ,without having to add more "ifs" and without put more objects attached to Seneca instance.

I was thinking in situations where we may desire to remove segments from specific action patterns, or remove all segments immediately, or even one specif segment immediately. 

Later, I was thinking that it do not need to be implemented with a class that extends EventEmitter. Anyway I'm available to do any changes, just let me know. 